### PR TITLE
fix memory leak & cpu exhaustion

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -1,6 +1,7 @@
 let infoData; 
 let score = 0;
 let total = 0;
+let streetViewService;
 
 function fetchData() {
     if (!infoData) {
@@ -24,6 +25,10 @@ function fetchData() {
     return infoData; // Return the promise for fetched data
 }
 
+function onStreetViewReady() {
+	streetViewService = new google.maps.StreetViewService();
+	initMap();
+}
 
 function initMap() {
     fetchData()
@@ -38,9 +43,6 @@ function initMap() {
             lng: lng
         };
 
-        // Initialize StreetViewService
-        var streetViewService = new google.maps.StreetViewService();
-
         // Search for the nearest panorama from the random coordinates
         streetViewService.getPanorama({
             location: latLng,
@@ -48,6 +50,8 @@ function initMap() {
         }, function(data, status) {
             if (status === "OK") {
                 // Display the panorama if found
+		// But first, clear any previous street view instances
+		document.getElementById("map").textContent = "";
                 var panorama = new google.maps.StreetViewPanorama(
                     document.getElementById("map"), {
                         position: data.location.latLng,

--- a/templates/index.html
+++ b/templates/index.html
@@ -56,7 +56,7 @@
     <div id="map"></div>
 </div>
     <script src="static/script.js"></script>
-    <script async defer src="https://maps.googleapis.com/maps/api/js?key=API_KEY&callback=initMap"></script>
+    <script async defer src="https://maps.googleapis.com/maps/api/js?key=API_KEY&callback=onStreetViewReady"></script>
     <div class="button-container">
         <!-- Rounded buttons for parties -->
         <button type="button" class="btn btn-primary rounded-button" style="background-color: #0087dc;" onclick="getPartyName(this)">Conservative</button>


### PR DESCRIPTION
I have a bit of a procrastination problem, and I've played this game for more rounds than I care to admit. But I noticed that after about 20 rounds, my CPU would start absolutely weeping, macOS would even disable desktop compositing to try and save some GPU cycles, every time I switched tabs to google where the hell a particular constituency was, it would take a good five seconds to render the game afterwards. I figured there must be a memory leak somewhere, turns out the old Street View elements are not deleted, they just rack up behind the current one in focus, so the load on the CPU and GPU increases linearly.

This PR recycles the `streetViewService` object every time we want to render a new panorama, and also clears the old elements from the DOM before adding new ones. Reduction in memory usage on my machine after ~15 rounds is about an order of magnitude, and no more noticeable load on the CPU.

Now I should really get back to work